### PR TITLE
Simplifies health endpoint

### DIFF
--- a/controllers/healthcheck.go
+++ b/controllers/healthcheck.go
@@ -1,15 +1,10 @@
 package controllers
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/prest/prest/adapters/postgres"
 )
-
-type HealthCheck struct {
-	Status string `json:"status"`
-}
 
 func CheckDBHealth() error {
 	conn, err := postgres.Get()
@@ -26,17 +21,10 @@ func CheckDBHealth() error {
 
 func WrappedHealthCheck(checkDBhealth func() error) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
 		if err := checkDBhealth(); err != nil {
-			http.Error(w, "unable to run queries on the database", http.StatusServiceUnavailable)
+			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
-
 		w.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(w).Encode(HealthCheck{"ok"}); err != nil {
-			http.Error(w, "unable to enconde json response", http.StatusServiceUnavailable)
-			return
-		}
 	}
 }


### PR DESCRIPTION
Simplifies the health endpoint:
* no need for body content: AFAIK, we don't have a use case for the body (usually systems check the HHTP status, right?)
* adds a simple test to `CheckDBHealth` to make sure it works on a properly set PostgreSQL